### PR TITLE
Added a custom async helper to make a mockAjax call

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -4,7 +4,12 @@ import Ember from 'ember';
 var Adapter;
 
 if(window.GoodcityENV.environment === "test") {
-  Adapter = DS.FixtureAdapter.extend();
+  Adapter = DS.RESTAdapter.extend({
+    headers: {
+      "Authorization":  'Bearer ' + localStorage.jwt,
+      "Accept-Language": Ember.I18n.translations.language
+    }
+  });
 } else {
   Adapter = DS.RESTAdapter.extend({
     namespace: GoodcityENV.APP.NAMESPACE,

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -47,7 +47,8 @@
     "currentRouteName",
     "mockjax",
     "FactoryGuy",
-    "FactoryGuyTestMixin"
+    "FactoryGuyTestMixin",
+    "mockApi"
   ],
   "node" : false,
   "browser" : false,

--- a/tests/helpers/mock-api.js
+++ b/tests/helpers/mock-api.js
@@ -1,0 +1,8 @@
+export default Ember.Test.registerAsyncHelper('mockApi', function (app,reqtype, url, json) {
+  $.mockjax({
+    type: reqtype,
+    url: url,
+    dataType: 'json',
+    responseText: json
+  });
+});

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -2,6 +2,7 @@
 
 var Application = require('goodcity/app')['default'];
 var Router = require('goodcity/router')['default'];
+import mockApi from './mock-api';
 
 export default function startApp(attrs) {
   var App;


### PR DESCRIPTION
Added a custom Async helper to make a call to MockAjax. To use this directly use `mockApi` helper

```
   mockApi('get', '/route_name', {json:data})

   To use it with FactoryGuy use like given example

    mockApi('get',
            '/territories',
            {territories: FactoryGuy.buildList('territory_with_many_districts', 3)});
```
