### PR TITLE
Handle redirection of user after login

### DIFF
--- a/app/components/complete-offer.js
+++ b/app/components/complete-offer.js
@@ -1,0 +1,13 @@
+import Ember from 'ember';
+
+//~ {{complete-offer offer=this}}
+
+export default Ember.Component.extend({
+
+  tagName: 'span',
+
+  isDraft: function() {
+    return this.get('offer.state') === 'draft';
+  }.property('offer.state'),
+
+});

--- a/app/controllers/offers/index.js
+++ b/app/controllers/offers/index.js
@@ -2,10 +2,9 @@ import Ember from 'ember';
 
 export default Ember.ArrayController.extend({
 
-  pendingOffer: function () {
-    var pending_offer = this.findBy('items.length',0);
-    var offer_id = pending_offer ? pending_offer.id : null;
-    return offer_id;
-  }.property("content.@each.itemCount")
+  powerUser: function () {
+    var pending_offer = this.filterBy('state', 'draft');
+    return (this.get('content.length') > pending_offer.length);
+  }.property("content.@each.state")
 
 });

--- a/app/routes/offers.js
+++ b/app/routes/offers.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import AuthorizeRoute from './authorize';
 
 export default AuthorizeRoute.extend({

--- a/app/routes/offers.js
+++ b/app/routes/offers.js
@@ -3,15 +3,15 @@ import AuthorizeRoute from './authorize';
 export default AuthorizeRoute.extend({
 
   beforeModel: function() {
+    this._super();
     var route = this;
     this.store.find('offer').then(function(my_offers){
-      var count = my_offers.get('length');
-      if ( count === 0) {
-        route.transitionTo('offers.new');
-      } else {
-        if (count === 1 && my_offers.get('firstObject.state') === 'draft') {
-          route.transitionTo('offer', my_offers.get('firstObject.id'));
-        }
+      switch(my_offers.get('length')) {
+        case 0 : route.transitionTo('offers.new'); break;
+        case 1 :
+          if(my_offers.get('firstObject.state') === 'draft') {
+            route.transitionTo('offer', my_offers.get('firstObject.id'));
+          }
       }
     });
   },

--- a/app/routes/offers.js
+++ b/app/routes/offers.js
@@ -1,22 +1,21 @@
+import Ember from 'ember';
 import AuthorizeRoute from './authorize';
 
 export default AuthorizeRoute.extend({
 
-  beforeModel: function() {
-    this._super();
-    var route = this;
-    this.store.find('offer').then(function(my_offers){
-      switch(my_offers.get('length')) {
-        case 0 : route.transitionTo('offers.new'); break;
-        case 1 :
-          if(my_offers.get('firstObject.state') === 'draft') {
-            route.transitionTo('offer', my_offers.get('firstObject.id'));
-          }
-      }
-    });
-  },
-
   model: function() {
     return this.store.find('offer');
+  },
+
+  afterModel: function(my_offers) {
+    var route = this;
+    switch(my_offers.get('length')) {
+      case 0 : route.transitionTo('offers.new'); break;
+      case 1 :
+        if(my_offers.get('firstObject.state') === 'draft') {
+          route.transitionTo('offer', my_offers.get('firstObject'));
+        }
+    }
   }
+
 });

--- a/app/routes/offers.js
+++ b/app/routes/offers.js
@@ -1,6 +1,21 @@
 import AuthorizeRoute from './authorize';
 
 export default AuthorizeRoute.extend({
+
+  beforeModel: function() {
+    var route = this;
+    this.store.find('offer').then(function(my_offers){
+      var count = my_offers.get('length');
+      if ( count === 0) {
+        route.transitionTo('offers.new');
+      } else {
+        if (count === 1 && my_offers.get('firstObject.state') === 'draft') {
+          route.transitionTo('offer', my_offers.get('firstObject.id'));
+        }
+      }
+    });
+  },
+
   model: function() {
     return this.store.find('offer');
   }

--- a/app/templates/components/complete-offer.hbs
+++ b/app/templates/components/complete-offer.hbs
@@ -1,6 +1,6 @@
-{{#link-to 'offer' this}}
+{{#link-to 'offer' offer}}
   {{#if isDraft }}
-    {{#link-to 'offer' this}}Complete this Offer{{/link-to}}
+    Complete this Offer
   {{else}}
     {{t offers.index.see_more}}
   {{/if}}

--- a/app/templates/components/complete-offer.hbs
+++ b/app/templates/components/complete-offer.hbs
@@ -1,5 +1,7 @@
-{{#if isDraft }}
-  {{#link-to 'offer' this}}Complete this Offer{{/link-to}}
-{{else}}
-  {{#link-to 'offer' this}}{{t offers.index.see_more}}{{/link-to}}
-{{/if}}
+{{#link-to 'offer' this}}
+  {{#if isDraft }}
+    {{#link-to 'offer' this}}Complete this Offer{{/link-to}}
+  {{else}}
+    {{t offers.index.see_more}}
+  {{/if}}
+{{/link-to}}

--- a/app/templates/components/complete-offer.hbs
+++ b/app/templates/components/complete-offer.hbs
@@ -1,0 +1,5 @@
+{{#if isDraft }}
+  {{#link-to 'offer' this}}Complete this Offer{{/link-to}}
+{{else}}
+  {{#link-to 'offer' this}}{{t offers.index.see_more}}{{/link-to}}
+{{/if}}

--- a/app/templates/offers/index.hbs
+++ b/app/templates/offers/index.hbs
@@ -1,6 +1,8 @@
-<p class='offer_link'>
-  {{#link-to 'offers.new'}}{{t offers.index.new_donation}}{{/link-to}}
-</p>
+{{#if powerUser}}
+  <p class='offer_link'>
+    {{#link-to 'offers.new'}}{{t offers.index.new_donation}}{{/link-to}}
+  </p>
+{{/if}}
 
 <h3>{{t offers.index.my_offers}}</h3>
 

--- a/app/templates/offers/index.hbs
+++ b/app/templates/offers/index.hbs
@@ -1,9 +1,5 @@
 <p class='offer_link'>
-  {{#if pendingOffer}}
-    {{#link-to 'offer.index' pendingOffer}}{{t offer.index.add_items}}{{/link-to}}
-  {{else}}
-    {{#link-to 'offers.new'}}{{t offers.index.new_donation}}{{/link-to}}
-  {{/if}}
+  {{#link-to 'offers.new'}}{{t offers.index.new_donation}}{{/link-to}}
 </p>
 
 <h3>{{t offers.index.my_offers}}</h3>
@@ -13,11 +9,10 @@
     <li class="contact">
       Offer_id: {{ id }}
       <br/>
-      {{t offers.index.name collectionContactNameBinding=collectionContactName}}
-      <br/>
       {{t offers.index.total_items itemCountBinding=itemCount}}
       <br/>
-      {{#link-to 'offer.index' this}}{{t offers.index.see_more}}{{/link-to}}
+      {{complete-offer offer=this}}
     </li>
+    <br/>
   {{/each}}
 </ul>

--- a/tests/acceptance/offers-test.js
+++ b/tests/acceptance/offers-test.js
@@ -19,8 +19,9 @@ test('Offers list & link to add items', function() {
   visit('/offers');
   andThen(function() {
     equal($('ul.offer_list li').length, 2);
-    // test: link to add items to existing offer
-    equal($('p.offer_link a').attr('href'), "/offers/2");
+
+    // test: link to complete offers
+    equal($("a:contains('Complete this Offer')").length, 2);
   });
 });
 
@@ -34,12 +35,11 @@ test("Offers Details", function() {
     var offer_detail_text = $.trim(offer_detail.replace(/\s+/g, " "));
 
     // test: offer details
-    equal(offer_detail_text, "Offer_id: 1 Name: TestOffer Total items: 2 See more...");
+    equal(offer_detail_text, "Offer_id: 1 Total items: 2 Complete this Offer");
 
-    // test: offer name
-    equal(/TestOffer/i.test($('ul.offer_list li').text()), true);
-
-    // test: show offer details link
-    equal($('ul.offer_list li').first().find('a').attr('href'), "/offers/1");
+    // test: complete this offer link
+    var complete_offer_link = $('ul.offer_list li').first().find('a');
+    equal(complete_offer_link.attr('href'), "/offers/1");
+    equal($.trim(complete_offer_link.text()), "Complete this Offer");
   });
 });


### PR DESCRIPTION
Completed with :
- [x] After registration, create a new dummy offer and redirect user to add-items into it.
- [x] After login, if user has only one offer(draft), redirect user to thar offer-page.
- [x] If user access 'All Offers' page,
  -  display 'complete this offer' button for all incomplete offer.
  -  display 'Make new donation'  link only if he is 'Power User'(has at least one submitted offer)

@steveyken, @shivanibhanwal  Can you please review the changes and let me know in case of any missing scenarios or further modifications.

Thanks.
